### PR TITLE
Create 2012-2020 StateIO data products with version number 0.2.1

### DIFF
--- a/.github/workflows/save-raw-data.yaml
+++ b/.github/workflows/save-raw-data.yaml
@@ -37,7 +37,7 @@ jobs:
       # R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -70,7 +70,7 @@ jobs:
       
       # Upload .rds files
       - name: Upload .rds files and prepare zip for manual download
-        uses: actions/upload-artifact@v2.3.0
+        uses: actions/upload-artifact@v3
         with:
           # Artifact name
           name: data and metadata
@@ -81,7 +81,7 @@ jobs:
       
       # Upload .json files 
       - name: Upload .json files and prepare zip for manual download
-        uses: actions/upload-artifact@v2.3.0
+        uses: actions/upload-artifact@v3
         with:
           # Artifact name
           name: data and metadata

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: stateior
 Type: Package
 Title: US State Input-Output (stateio) R modeling software
-Version: 0.2.0
-Date: 2022-05-17
+Version: 0.2.1
+Date: 2022-10-20
 Authors@R: c(
   person("Mo", "Li", email="mo.li@gdit.com", role="aut"),
   person("Joao-Pedro", "Ferreira", email="joao.ferreira@ufl.edu", role= c("aut")),

--- a/R/BuildModel.R
+++ b/R/BuildModel.R
@@ -1,5 +1,6 @@
 # Define model version
-model_ver <- utils::packageDescription(pkg = "stateior", fields = "Version")
+# model_ver <- utils::packageDescription(pkg = "stateior", fields = "Version")
+model_ver <- NULL
 
 #' Build a state supply model for all 52 states/regions (including DC and Overseas)
 #' for a given year

--- a/R/UtilityFunctions.R
+++ b/R/UtilityFunctions.R
@@ -145,6 +145,9 @@ getTwoRegionDataFileName <- function(year, iolevel, dataname) {
 #' @param year A numeric value between 2007 and 2017 specifying the year of interest.
 #' @return A data frame contains state data from FLOWSA.
 getFlowsaData <- function(dataname, year) {
+  if (is.null(model_ver)) {
+    model_ver <- "NULL"
+  }
   # Load metadata
   if (dataname == "Employment") {
     meta <- configr::read.config(system.file("extdata/", "FlowBySector_metadata.yml",

--- a/data-raw/BEAData_wAPI.R
+++ b/data-raw/BEAData_wAPI.R
@@ -45,6 +45,7 @@ getBEAStateEmployment <- function(year) {
     DateLastModified_linecode <- stringr::str_match(toString(notes),
                                                     "Last updated: (.*?)--")[2]
     DateLastModified <- rbind(DateLastModified, DateLastModified_linecode)
+    Sys.sleep(3)
   }
   
   # Save data

--- a/data-raw/BEAData_wAPI.R
+++ b/data-raw/BEAData_wAPI.R
@@ -74,4 +74,7 @@ getBEAStateEmployment <- function(year) {
   }
 }
 # Download, save and document BEA state employment data
-getBEAStateEmployment(year)
+for (year in 2012:2020) {
+  getBEAStateEmployment(year)
+  print(year)
+}

--- a/inst/extdata/FlowByActivity_metadata.yml
+++ b/inst/extdata/FlowByActivity_metadata.yml
@@ -1,14 +1,25 @@
 USDA_ERS_FIWS:
-  0.1.0:
+  0.1.0: &usda_ext_12-17
     Extension: "v0.0.2_5d6373b.parquet"
   0.2.0:
-    2018:
+    2018: &usda_ext_18
       Extension: "v1.2.1_ef8b381.parquet"
-    2019: &usda_ext
+    2019: &usda_ext_19-20
       Extension: "v1.2.4_7c15ea5.parquet"
-    2020: *usda_ext
-      
+    2020: *usda_ext_19-20
+  "NULL":
+    2012: *usda_ext_12-17
+    2013: *usda_ext_12-17
+    2014: *usda_ext_12-17
+    2015: *usda_ext_12-17
+    2016: *usda_ext_12-17
+    2017: *usda_ext_12-17
+    2018: *usda_ext_18
+    2019: *usda_ext_19-20
+    2020: *usda_ext_19-20
+
 NOAA_FisheriesLandings:
   0.1.0: &noaa_ext
     Extension: "v1.2.4_7c15ea5.parquet"
   0.2.0: *noaa_ext
+  "NULL": *noaa_ext

--- a/inst/extdata/FlowBySector_metadata.yml
+++ b/inst/extdata/FlowBySector_metadata.yml
@@ -1,9 +1,19 @@
 Employment:
-  0.1.0:
+  0.1.0: &ext_12-17
     Extension: "v1.1_37dee46.parquet"
   0.2.0:
-    2018: &ext
+    2018: &ext_18-19
       Extension: "v1.2.3_aaf5403.parquet"
-    2019: *ext
-    2020:
+    2019: *ext_18-19
+    2020: &ext_20
       Extension: "v1.2.4_7c15ea5.parquet"
+  "NULL":
+    2012: *ext_12-17
+    2013: *ext_12-17
+    2014: *ext_12-17
+    2015: *ext_12-17
+    2016: *ext_12-17
+    2017: *ext_12-17
+    2018: *ext_18-19
+    2019: *ext_18-19
+    2020: *ext_20


### PR DESCRIPTION
## Purpose
- Integrate v0.1.0 (2012-2017) and v0.2.0 (2018-2020) data products to create v0.2.1 (2012-2020) data products
## What's changed and unchanged
- No data updates or methodological changes are involved - meaning v0.2.1 intermediate (state IO tables) and final products (two-region IO tables) will use the latest raw data (v0.1.0 or v0.2.0) on [Data Commons](https://edap-ord-data-commons.s3.amazonaws.com/index.html?prefix=stateio/)
## What's need to be done
- Execute only [steps 2-4](https://github.com/USEPA/stateior/wiki/Model-Approach) to create v0.2.1 StateIO data products